### PR TITLE
Check if a branch or leaf is selectable before selcting/deselcting it

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "polymer": "^1.9.0",
     "px-icon-set": "^2.0.0",
-    "px-app-helpers": "^1.0.0",
+    "px-app-helpers": "^1.4.0",
     "iron-collapse": "^2.0.0"
   },
   "devDependencies": {

--- a/px-tree.html
+++ b/px-tree.html
@@ -120,6 +120,8 @@ Polymer({
   },
   _handleNodeTapped: function(e) {
     const {shift, ctrl, item, isBranch, isActive, isSelected, isIcon} = e.detail;
+    const isSelectable = this._assetGraph.isSelectable(item);
+
     if(isBranch && !isActive) {
       this.activate(item);
     }
@@ -132,6 +134,7 @@ Polymer({
       }
     }
     if(isBranch && this.disableBranchSelect || isIcon) return;
+    if (!isSelectable) return;
     if(isSelected && (ctrl || shift)) {
       this.deselect(item);
       return;


### PR DESCRIPTION
When the user taps on a leaf/branch, checks if the `isSelectable` property on the item was set to false. If it was set to false, skips selecting/deselecting and only allows activate behaviors to happen.

@randyaskin I think this was the right place to put the check in. Does this look right to you? Add `"isSelectable" : false` to an item in the items array to test this out.